### PR TITLE
Bugfix and improvments

### DIFF
--- a/org.dupot.easyflatpak.yml
+++ b/org.dupot.easyflatpak.yml
@@ -34,10 +34,10 @@ modules:
     sources:
       - type: archive
         dest: EasyFlatpakArchive
-        url: https://github.com/imikado/dupotEasyFlatpak/releases/download/3.12.3/bundle.tar.gz
-        sha256: baca1d34e65613fceceaf65087a59403c389787f1ff83ed41e9c7d66bc14ca6c
+        url: https://github.com/imikado/dupotEasyFlatpak/releases/download/3.12.4/bundle.tar.gz
+        sha256: 13a4235857467da2815a259ed3d1747534fd7917212eead6004931bc1748ed31
       - type: git
         dest: git_repo
         url: https://github.com/imikado/dupotEasyFlatpak
-        tag: 3.12.3
-        commit: 7b6e115e3ce21d326df09fdc4f86e90718a43839
+        tag: 3.12.4
+        commit: 1fe4b859b886197117064276b2bf58c2e1947b9c


### PR DESCRIPTION
translate missing keys
enable log file even if release
change behavior of translate api: if missing avoid crash