### PR TITLE
update application database from flathub api

### DIFF
--- a/org.dupot.easyflatpak.yml
+++ b/org.dupot.easyflatpak.yml
@@ -34,10 +34,10 @@ modules:
     sources:
       - type: archive
         dest: EasyFlatpakArchive
-        url: https://github.com/imikado/dupotEasyFlatpak/releases/download/3.15.0/bundle.tar.gz
-        sha256: 721bd1a6f21c906c9b2cf6b7e55e0d3f3b583405bc5a4b491394629fd8a3d0a3
+        url: https://github.com/imikado/dupotEasyFlatpak/releases/download/3.16.0/bundle.tar.gz
+        sha256: fbc6cb2bd4d95e0f142b5227907afc72862dd4e1667c40766796c2fa6719af7d
       - type: git
         dest: git_repo
         url: https://github.com/imikado/dupotEasyFlatpak
-        tag: 3.15.0
-        commit: 34b8ef5598a30d5b27654523561b6e13945e21c7
+        tag: 3.16.0
+        commit: 7b959b048393ae357c11abd2c55d70c3f5b0f692

--- a/org.dupot.easyflatpak.yml
+++ b/org.dupot.easyflatpak.yml
@@ -9,7 +9,7 @@ finish-args:
   - --share=ipc
   - --device=dri
   - --talk-name=org.freedesktop.Flatpak
-  - --filesystem=xdg-documents
+  - --filesystem=home
   - --share=network
 
 modules:
@@ -34,10 +34,10 @@ modules:
     sources:
       - type: archive
         dest: EasyFlatpakArchive
-        url: https://github.com/imikado/dupotEasyFlatpak/releases/download/3.14.1/bundle.tar.gz
-        sha256: 2603037c868bbe223d602238a97853dff6b2112468be7ee0e0bdd20c6c178227
+        url: https://github.com/imikado/dupotEasyFlatpak/releases/download/3.15.0/bundle.tar.gz
+        sha256: 721bd1a6f21c906c9b2cf6b7e55e0d3f3b583405bc5a4b491394629fd8a3d0a3
       - type: git
         dest: git_repo
         url: https://github.com/imikado/dupotEasyFlatpak
-        tag: 3.14.1
-        commit: 2a87230a1d65db2c4a61830c919a7654b553da28
+        tag: 3.15.0
+        commit: 34b8ef5598a30d5b27654523561b6e13945e21c7

--- a/org.dupot.easyflatpak.yml
+++ b/org.dupot.easyflatpak.yml
@@ -34,10 +34,10 @@ modules:
     sources:
       - type: archive
         dest: EasyFlatpakArchive
-        url: https://github.com/imikado/dupotEasyFlatpak/releases/download/3.16.0/bundle.tar.gz
-        sha256: fbc6cb2bd4d95e0f142b5227907afc72862dd4e1667c40766796c2fa6719af7d
+        url: https://github.com/imikado/dupotEasyFlatpak/releases/download/3.16.1/bundle.tar.gz
+        sha256: d99e12d0360f2bdd088841ee886be81074da09d348e7430e7570e947ee0e1d70
       - type: git
         dest: git_repo
         url: https://github.com/imikado/dupotEasyFlatpak
-        tag: 3.16.0
-        commit: 7b959b048393ae357c11abd2c55d70c3f5b0f692
+        tag: 3.16.1
+        commit: 8e931c435145c818ab4939b1a012d57874096895


### PR DESCRIPTION
reorganize way to store datas, now in .config/Easyflatpak, .log/Easyflatpak , .cache/Easyflatpak modify permission from Documents to home to allow application to store in .config, .log and .cache directories