### PR TITLE
update runtime to org.freedesktop.Platform 25.08

### DIFF
--- a/org.dupot.easyflatpak.yml
+++ b/org.dupot.easyflatpak.yml
@@ -1,6 +1,6 @@
 app-id: org.dupot.easyflatpak
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 command: dupot_easy_flatpak
 finish-args:


### PR DESCRIPTION
Upgrade runtime from `org.freedesktop.Platform`  `23.08` to `25.08`.

The `23.08` runtime has reached end-of-life and is no longer receiving fixes or security updates:
```
Info: runtime org.freedesktop.Platform branch 23.08 is end-of-life, with reason:
  org.freedesktop.Platform 23.08 is no longer receiving fixes and security updates.
  Please update to a supported runtime version.
```
Tested briefly, no issues noticed.
